### PR TITLE
Fix handling quotes in kernel parameters

### DIFF
--- a/lilo.new
+++ b/lilo.new
@@ -799,16 +799,15 @@ function parse_config_file () {
 
     CONFIG_IMAGE_COUNT=0
     OPTION_BOOT_COUNT=0
-    while read; do
+    while read -r; do
 	# strip comments, heading and trailing whitespace and empty lines
 	REPLY=${REPLY%%#*}
 	REPLY=${REPLY%%+([ 	])}
 	REPLY=${REPLY##+([ 	])}
 	if [ -z "$REPLY" ]; then continue; fi
 	REPLY=${REPLY/=/ = }
-	REPLY=${REPLY/\"\"/}	# replace quoted empty string by "itself"
- 
-	read option separator value <<< "$REPLY"
+
+	read -r option separator value <<< "$REPLY"
 	#	echo option "$option"
 	#	echo separator "$separator"
 	#	echo value $value
@@ -817,6 +816,7 @@ function parse_config_file () {
 	    echo "Illegal separator '$separator', line ignored"
 	    continue
 	fi
+	[ "$value" = '""' ] && value=""	# replace quoted empty string by "itself"
 
 	case "$option" in
 	    boot)
@@ -909,12 +909,16 @@ function parse_config_file () {
 	    append)
 		# FIXME: fix some common typos like missing quotes of spaces
 		# like that? "'${a//*( )=*( )/=}'"
+		# Do NOT use eval to not strip \
+		# Only iSeries uses unquoted arguments merged with root=. Every
+		# other platform adds the quotes again when printing out the
+		# config ...
+		value=${value##\"}
+		value=${value%%\"}
 		if [ -z "$CONFIG_PARSE_HASIMAGE" ] ; then
-		    # use eval to strip ""
-		    eval OPTION_APPEND=$value
+		    OPTION_APPEND=$value
 		else
-		    # use eval to strip ""
-		    eval CONFIG_IMAGE_APPEND[$CONFIG_IMAGE_COUNT]=$value
+		    CONFIG_IMAGE_APPEND[$CONFIG_IMAGE_COUNT]=$value
 		fi
 		;;
 	    sysmap)


### PR DESCRIPTION
You should be able to say 
append = "param=value foo=bar\"baz\""
and pass that to yaboot which passes it to the kernel with one level of quoting stripped.
